### PR TITLE
feat: match flavor only once

### DIFF
--- a/src/bin/builder.rs
+++ b/src/bin/builder.rs
@@ -1,5 +1,6 @@
 #![feature(io_error_more)]
 
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
@@ -105,6 +106,7 @@ fn calc_flavors(manifest: &manifest::Manifest) -> Vec<Flavor> {
         })
     }
 
+    let mut processed = HashSet::new();
     for rule in &docs.flavors {
         let mut name_feats: Vec<(String, Vec<String>)> = Vec::new();
         match (&rule.name, &rule.regex_feature) {
@@ -112,7 +114,10 @@ fn calc_flavors(manifest: &manifest::Manifest) -> Vec<Flavor> {
             (None, Some(re)) => {
                 let re = Regex::new(&format!("^{}$", re)).unwrap();
                 for feature in manifest.features.keys().filter(|s| re.is_match(s)) {
-                    name_feats.push((feature.clone(), vec![feature.clone()]))
+                    if !processed.contains(feature) {
+                        name_feats.push((feature.clone(), vec![feature.clone()]));
+                        processed.insert(feature.clone());
+                    }
                 }
             }
             _ => panic!(


### PR DESCRIPTION
Instead of matching the same flavor multiple times, which can cause
issues like incompatible feature flags set, skip processing a flavor the
second time.

This enables an 'eager matching' policy where the first flavor rule that
matches gets to set the features for that flavor.

This is needed in some cases where one would like to specify a more
strict regexp matching certain flavors in embassy-stm32.
